### PR TITLE
fix: Re-enable patch fix for "App not responding" dialog

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,5 +4,4 @@ meson-add-back-default_driver-option.patch
 x11-Add-support-for-fractional-scaling-using-Randr.patch
 debian/synaptics-support.patch
 debian/tests-Tag-closed-transient-no-input-tests-as-flaky.patch
-# Disabled for causing hangs with NVIDIA
-# x11-Update-X11-focus-before-updating-MetaDisplay-focus.patch
+x11-Update-X11-focus-before-updating-MetaDisplay-focus.patch


### PR DESCRIPTION
Check to see if this is causing NVIDIA systems to hang.
Prevents the system from hanging when an "app is not responding" dialog is displayed.