### PR TITLE
Backport X11 input event fixes

### DIFF
--- a/debian/patches/0001-clutter-event-Do-not-filter-out-DEVICE_ADDED-REMOVED.patch
+++ b/debian/patches/0001-clutter-event-Do-not-filter-out-DEVICE_ADDED-REMOVED.patch
@@ -1,0 +1,37 @@
+From 41434d548858e1f07da045cd3b6b0f10140fcde1 Mon Sep 17 00:00:00 2001
+From: Carlos Garnacho <carlosg@gnome.org>
+Date: Fri, 6 Nov 2020 17:59:33 +0100
+Subject: [PATCH 1/2] clutter/event: Do not filter out DEVICE_ADDED/REMOVED
+ events
+
+These devices in x11 are "disabled", that doesn't mean we should refrain
+from notifying about them.
+
+Fixes: https://gitlab.gnome.org/GNOME/mutter/-/issues/1476
+Fixes: https://gitlab.gnome.org/GNOME/mutter/-/issues/1496
+
+https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1553
+
+(cherry-picked from commit 34710eabc0dc2154d26296f3121728683af4afe6)
+---
+ clutter/clutter/clutter-event.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/clutter/clutter/clutter-event.c b/clutter/clutter/clutter-event.c
+index 8a7896091..7586a59c5 100644
+--- a/clutter/clutter/clutter-event.c
++++ b/clutter/clutter/clutter-event.c
+@@ -1582,7 +1582,9 @@ _clutter_event_push (const ClutterEvent *event,
+   device = clutter_event_get_device (event);
+   if (device != NULL)
+     {
+-      if (!clutter_input_device_get_enabled (device))
++      if (event->type != CLUTTER_DEVICE_ADDED &&
++          event->type != CLUTTER_DEVICE_REMOVED &&
++          !clutter_input_device_get_enabled (device))
+         return;
+     }
+ 
+-- 
+2.27.0
+

--- a/debian/patches/0002-backends-x11-Emit-CLUTTER_DEVICE_ADDED-events-for-in.patch
+++ b/debian/patches/0002-backends-x11-Emit-CLUTTER_DEVICE_ADDED-events-for-in.patch
@@ -1,0 +1,91 @@
+From 1f16a134414747ac378fb5085a99d1ccc8e7a4e2 Mon Sep 17 00:00:00 2001
+From: Carlos Garnacho <carlosg@gnome.org>
+Date: Fri, 6 Nov 2020 18:00:55 +0100
+Subject: [PATCH 2/2] backends/x11: Emit CLUTTER_DEVICE_ADDED events for
+ initial devices
+
+This is similar to commit b9e5a2d6e23, but for the X11 backend.
+
+Fixes: https://gitlab.gnome.org/GNOME/mutter/-/issues/1466
+Fixes: https://gitlab.gnome.org/GNOME/mutter/-/issues/1495
+
+https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1553
+
+(cherry-picked from commit b6211bb6842fd7f88bc4f70f0d268614b85f4b3d)
+---
+ src/backends/x11/meta-backend-x11.c |  7 +++++++
+ src/backends/x11/meta-seat-x11.c    | 19 +++++++++++++++++++
+ src/backends/x11/meta-seat-x11.h    |  2 ++
+ 3 files changed, 28 insertions(+)
+
+diff --git a/src/backends/x11/meta-backend-x11.c b/src/backends/x11/meta-backend-x11.c
+index 7bb8ff3d1..e18e6a1ab 100644
+--- a/src/backends/x11/meta-backend-x11.c
++++ b/src/backends/x11/meta-backend-x11.c
+@@ -524,6 +524,8 @@ meta_backend_x11_post_init (MetaBackend *backend)
+   MetaBackendX11 *x11 = META_BACKEND_X11 (backend);
+   MetaBackendX11Private *priv = meta_backend_x11_get_instance_private (x11);
+   MetaMonitorManager *monitor_manager;
++  ClutterBackend *clutter_backend;
++  ClutterSeat *seat;
+   int major, minor;
+   gboolean has_xi = FALSE;
+ 
+@@ -576,6 +578,11 @@ meta_backend_x11_post_init (MetaBackend *backend)
+   priv->touch_replay_sync_atom = XInternAtom (priv->xdisplay,
+                                               "_MUTTER_TOUCH_SEQUENCE_SYNC",
+                                               False);
++
++  clutter_backend = meta_backend_get_clutter_backend (backend);
++  seat = clutter_backend_get_default_seat (clutter_backend);
++  meta_seat_x11_notify_devices (META_SEAT_X11 (seat),
++                                CLUTTER_STAGE (meta_backend_get_stage (backend)));
+ }
+ 
+ static ClutterBackend *
+diff --git a/src/backends/x11/meta-seat-x11.c b/src/backends/x11/meta-seat-x11.c
+index 6f0db3a7f..491b82fae 100644
+--- a/src/backends/x11/meta-seat-x11.c
++++ b/src/backends/x11/meta-seat-x11.c
+@@ -1383,6 +1383,25 @@ meta_seat_x11_get_property (GObject    *object,
+     }
+ }
+ 
++void
++meta_seat_x11_notify_devices (MetaSeatX11  *seat_x11,
++			      ClutterStage *stage)
++{
++  GHashTableIter iter;
++  ClutterInputDevice *device;
++
++  g_hash_table_iter_init (&iter, seat_x11->devices_by_id);
++  while (g_hash_table_iter_next (&iter, NULL, (gpointer *) &device))
++    {
++      ClutterEvent *event;
++
++      event = clutter_event_new (CLUTTER_DEVICE_ADDED);
++      clutter_event_set_device (event, device);
++      clutter_event_set_stage (event, stage);
++      clutter_do_event (event);
++    }
++}
++
+ static void
+ meta_seat_x11_constructed (GObject *object)
+ {
+diff --git a/src/backends/x11/meta-seat-x11.h b/src/backends/x11/meta-seat-x11.h
+index d27ec5fa9..924025802 100644
+--- a/src/backends/x11/meta-seat-x11.h
++++ b/src/backends/x11/meta-seat-x11.h
+@@ -36,6 +36,8 @@ ClutterInputDevice * meta_seat_x11_lookup_device_id (MetaSeatX11 *seat_x11,
+                                                      int          device_id);
+ void meta_seat_x11_select_stage_events (MetaSeatX11  *seat,
+                                         ClutterStage *stage);
++void meta_seat_x11_notify_devices (MetaSeatX11  *seat_x11,
++                                   ClutterStage *stage);
+ 
+ G_END_DECLS
+ 
+-- 
+2.27.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,5 @@ clutter-event-Add-device-added-removed-events.patch
 clutter-seat-Handle-device-events-and-emit-signals.patch
 seat-x11-Translate-device-enabled-disabled-into-clutter-e.patch
 seat-native-Process-device-added-removed-events-as-Clutte.patch
+0001-clutter-event-Do-not-filter-out-DEVICE_ADDED-REMOVED.patch
+0002-backends-x11-Emit-CLUTTER_DEVICE_ADDED-events-for-in.patch


### PR DESCRIPTION
From upstream gnome-3-36 branch. This seems somewhat important, and it isn't clear if/when a new 3.36 release will occur.

This should address https://github.com/pop-os/gnome-control-center/issues/120 on focal.